### PR TITLE
listen using API_RPC* env vars

### DIFF
--- a/scripts/rpc.js
+++ b/scripts/rpc.js
@@ -3,8 +3,10 @@ const rpcHandlers = require('../lib/api/rpc');
 
 const server = jayson.server(rpcHandlers);
 
-const bindHost = process.env.BIND_HOST || '0.0.0.0';
-server.http().listen(5001, bindHost);
+server.http().listen(
+  process.env.API_RPC_PORT,
+  process.env.API_RPC_HOST || '0.0.0.0',
+);
 
 // break on ^C
 process.on('SIGINT', () => {


### PR DESCRIPTION
Use `API_RPC_PORT` and `API_RPC_HOST` to define local socket to bind to for API service.

This is part of PR #11 which I've broken into a smaller & focused PR. Have reviewed & approved this particular change set.