### PR TITLE
[DD-104] Force using "use strict"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "airbnb-base",
   "rules": {
+    "strict": ["warn", "global"],
     "no-plusplus": 0,
     "eol-last": [
       "error",


### PR DESCRIPTION
https://dashpay.atlassian.net/browse/DD-104

Added 'strict' rule to eslintrc config file so that the linter will complain when developers accidentally declare global variables, etc. This rule will eliminate silent JS errors, fix mistakes that result in poor optimization, prohibit bad syntax.

- added 'strict' rule to eslintrc
- added array containing rule options, i.e. 'global' and 'warn'