### PR TITLE
fix: internal errors are not logged

### DIFF
--- a/lib/abci/errors/wrapInErrorHandlerFactory.js
+++ b/lib/abci/errors/wrapInErrorHandlerFactory.js
@@ -42,6 +42,9 @@ function wrapInErrorHandlerFactory(logger) {
       } catch (e) {
         let error = e;
 
+        // Log all errors
+        logger.error(e);
+
         // Wrap all non ABCI errors to an internal ABCI error
         if (!(e instanceof AbciError)) {
           // in special cases (e.g. deliverTx call)
@@ -52,11 +55,6 @@ function wrapInErrorHandlerFactory(logger) {
           }
 
           error = new InternalAbciError(e);
-        }
-
-        // Log only internal ABCI errors
-        if (error instanceof InternalAbciError) {
-          logger.error(error.getError());
         }
 
         const kvPairTags = Object.entries(error.getTags())

--- a/lib/abci/errors/wrapInErrorHandlerFactory.js
+++ b/lib/abci/errors/wrapInErrorHandlerFactory.js
@@ -27,11 +27,9 @@ function wrapInErrorHandlerFactory(logger) {
   function wrapInErrorHandler(method, options = {}) {
     // eslint-disable-next-line no-param-reassign
     options = {
-      throwNonABCIErrors: true,
+      respondWithInternalError: false,
       ...options,
     };
-
-    const { throwNonABCIErrors } = options;
 
     /**
      * @param request
@@ -42,19 +40,23 @@ function wrapInErrorHandlerFactory(logger) {
       } catch (e) {
         let error = e;
 
-        // Log all errors
-        logger.error(e);
-
         // Wrap all non ABCI errors to an internal ABCI error
         if (!(e instanceof AbciError)) {
-          // in special cases (e.g. deliverTx call)
+          error = new InternalAbciError(e);
+        }
+
+        // Log only internal ABCI errors
+        if (error instanceof InternalAbciError) {
+          logger.error(error.getError());
+
+          // in consensus ABCI handlers (blockBegin, deliverTx, blockEnd, commit)
           // we should propagate the error upwards
           // to halt the Drive
-          if (throwNonABCIErrors) {
-            throw e;
+          // in order cases like query and checkTx
+          // we need to respond with internal errors
+          if (!options.respondWithInternalError) {
+            throw error.getError();
           }
-
-          error = new InternalAbciError(e);
         }
 
         const kvPairTags = Object.entries(error.getTags())

--- a/lib/createDIContainer.js
+++ b/lib/createDIContainer.js
@@ -438,11 +438,11 @@ async function createDIContainer(options) {
       queryHandler,
     ) => ({
       info: infoHandler,
-      checkTx: wrapInErrorHandler(checkTxHandler, { throwNonABCIErrors: false }),
+      checkTx: wrapInErrorHandler(checkTxHandler, { respondWithInternalError: true }),
       beginBlock: beginBlockHandler,
       deliverTx: wrapInErrorHandler(deliverTxHandler),
       commit: commitHandler,
-      query: wrapInErrorHandler(queryHandler, { throwNonABCIErrors: false }),
+      query: wrapInErrorHandler(queryHandler, { respondWithInternalError: true }),
     })).singleton(),
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal errors are throwing without logging in case of consensus ABCI handlers

## What was done?
<!--- Describe your changes in detail -->
* Renamed `throwNonABCIErrors` option to `respondWithInternalError`.
* Log internal errors in all cases

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
