### PR TITLE
fix: `header` is not present in `RequestEndBlock`

### DIFF
--- a/lib/abci/handlers/endBlockHandlerFactory.js
+++ b/lib/abci/handlers/endBlockHandlerFactory.js
@@ -30,10 +30,10 @@ function endBlockHandlerFactory(
    * @param {abci.RequestBeginBlock} request
    * @return {Promise<abci.ResponseBeginBlock>}
    */
-  async function endBlockHandler({ header }) {
-    logger.info(`Block end #${header.height}`);
+  async function endBlockHandler({ height }) {
+    logger.info(`Block end #${height}`);
 
-    if (dpnsContractId && header.height === dpnsContractBlockHeight) {
+    if (dpnsContractId && height === dpnsContractBlockHeight) {
       const transaction = blockExecutionDBTransactions.getTransaction('dataContract');
 
       const contract = await dataContractRepository.fetch(dpnsContractId, transaction);

--- a/lib/createDIContainer.js
+++ b/lib/createDIContainer.js
@@ -472,7 +472,7 @@ async function createDIContainer(options) {
       checkTx: wrapInErrorHandler(checkTxHandler, { respondWithInternalError: true }),
       beginBlock: beginBlockHandler,
       deliverTx: wrapInErrorHandler(deliverTxHandler),
-      endBlock: wrapInErrorHandler(endBlockHandler, { respondWithInternalError: true }),
+      endBlock: endBlockHandler,
       commit: commitHandler,
       query: wrapInErrorHandler(queryHandler, { respondWithInternalError: true }),
     })).singleton(),

--- a/test/unit/abci/handlers/endBlockHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/endBlockHandlerFactory.spec.js
@@ -14,7 +14,6 @@ describe('endBlockHandlerFactory', () => {
   let dataContractRepositoryMock;
   let request;
   let blockExecutionDBTransactionsMock;
-  let header;
   let dpnsContractId;
   let dpnsContractBlockHeight;
   let blockHeight;
@@ -49,18 +48,8 @@ describe('endBlockHandlerFactory', () => {
 
     blockHeight = 2;
 
-    header = {
-      version: {
-        App: 1,
-      },
-      height: blockHeight,
-      time: {
-        seconds: Math.ceil(new Date().getTime() / 1000),
-      },
-    };
-
     request = {
-      header,
+      height: blockHeight,
     };
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
TypeError: Cannot read property 'height' of undefined
drive_abci_1             |         at endBlockHandler (/usr/src/app/lib/abci/handlers/endBlockHandlerFactory.js:34:38)
drive_abci_1             |         at Object.methodErrorHandler [as endBlock] (/usr/src/app/lib/abci/errors/wrapInErrorHandlerFactory.js:41:22)
drive_abci_1             |         at Connection.onMessage (/node_modules/abci/src/server.js:47:28)
drive_abci_1             |         at Connection.maybeReadNextMessage (/node_modules/abci/src/connection.js:65:10)
drive_abci_1             |         at Connection.onData (/node_modules/abci/src/connection.js:32:10)
drive_abci_1             |         at Socket.emit (events.js:314:20)
drive_abci_1             |         at addChunk (_stream_readable.js:298:12)
drive_abci_1             |         at readableAddChunk (_stream_readable.js:273:9)
drive_abci_1             |         at Socket.Readable.push (_stream_readable.js:214:10)
drive_abci_1             |         at TCP.onStreamRead (internal/stream_base_commons.js:188:23)
```

## What was done?
<!--- Describe your changes in detail -->
- Fix the end block request param.
- Remove unnecessary error wrapper.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
