### PR TITLE
feat: build multi-arch docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: bionic
 language: node_js
 
@@ -11,19 +10,21 @@ branches:
     - /^v(0|[1-9]\d*)\.(0|[1-9]\d*)-dev$/
     - /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
 
-services:
-  - docker
-
 addons:
   apt:
+    update: true
+    sources:
+      - sourceline: 'deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable'
     packages:
-      - docker-ce
       - jq
 
 env:
-  - DOCKER_COMPOSE_VERSION=1.25.5
+  global:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - DOCKER_COMPOSE_VERSION=1.25.5
 
 before_install:
+  - sudo apt-get -y install docker-ce
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
@@ -31,6 +32,8 @@ before_install:
   - if [[ -n $SDK_BRANCH ]]; then export SDK_INSTALL=github:dashevo/DashJS#$SDK_BRANCH; fi
 
 install:
+  - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+  - docker buildx create --name xbuilder --use
   - npm ci
   - cp .env.example .env
   # Get the latest version of travis-ci-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:12-alpine
 RUN apk update && \
     apk --no-cache upgrade && \
     apk add --no-cache linux-headers \
+                       cmake \
                        git \
                        openssh-client \
                        python \

--- a/bin/travis-deploy.sh
+++ b/bin/travis-deploy.sh
@@ -44,11 +44,12 @@ if [[ -z "$PRERELEASE" ]]; then
 fi
 
 # Build an image with multiple tags
-docker build --build-arg NODE_ENV=development \
+docker buildx build --build-arg NODE_ENV=development \
   -t "${IMAGE_NAME}:${MAJOR}${TAG_POSTFIX}" \
   -t "${IMAGE_NAME}:${MAJOR}.${MINOR}${TAG_POSTFIX}" \
   -t "${IMAGE_NAME}:${MAJOR}.${MINOR}.${PATCH}${TAG_POSTFIX}" \
   -t "${IMAGE_NAME}:${LAST_TAG}" \
+  --platform linux/amd64,linux/arm64,linux/arm/v7 \
   .
 
 # Login to Docker Hub


### PR DESCRIPTION
Build multi-arch docker images to support ARM architecture

## Issue being fixed or feature implemented
This modifies Travis CI to build ARM images so we can begin to support the evo stack on devices like Raspberry Pi or AWS Graviton2.


## What was done?
Change docker environment and build command to add arm64 and arm/v7 images. Explicitly added cmake to build container, since this was not available for ARM builder for some reason.


## How Has This Been Tested?
Tested locally with no problems. Tested on Travis from my branch, but was not able to test actually deploying the image to Docker Hub.


## Breaking Changes
Because this requires emulation, it will increase the build time on CI.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
