### PR TITLE
fix: e.getErrors is not a function error

### DIFF
--- a/lib/abci/handlers/deliverTxHandlerFactory.js
+++ b/lib/abci/handlers/deliverTxHandlerFactory.js
@@ -59,7 +59,7 @@ function deliverTxHandlerFactory(
       if (e instanceof InvalidArgumentAbciError) {
         logger.info('State transition structure is invalid');
         logger.debug({
-          errors: e.getErrors(),
+          error: e,
         });
       }
 

--- a/test/unit/abci/handlers/deliverTxHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/deliverTxHandlerFactory.spec.js
@@ -171,4 +171,23 @@ describe('deliverTxHandlerFactory', () => {
       expect(blockExecutionContextMock.incrementAccumulativeFees).to.not.be.called();
     }
   });
+
+  it('should throw InvalidArgumentAbciError if a state transition structure is not valid', async () => {
+    const errorMessage = 'Invalid structure';
+    const error = new InvalidArgumentAbciError(errorMessage);
+
+    unserializeStateTransitionMock.throws(error);
+
+    try {
+      await deliverTxHandler(documentRequest);
+
+      expect.fail('should throw InvalidArgumentAbciError error');
+    } catch (e) {
+      expect(e).to.be.instanceOf(InvalidArgumentAbciError);
+      expect(e.getMessage()).to.equal(errorMessage);
+      expect(e.getCode()).to.equal(AbciError.CODES.INVALID_ARGUMENT);
+      expect(blockExecutionContextMock.incrementAccumulativeFees).to.not.be.called();
+      expect(dppMock.stateTransition.validateData).to.not.be.called();
+    }
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
e.getErrors is not a function error

## What was done?
<!--- Describe your changes in detail -->
fixed e.getErrors is not a function error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
