### PR TITLE
fix: allow tests to run on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 
 before_script:
   - print-bells
-  - source ./bin/start-local-node.sh $TRAVIS_BUILD_DIR/package.json --override-major-version=0 --dapi-branch=$DAPI_BRANCH --drive-branch=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
+  - source ./bin/start-local-node.sh $TRAVIS_BUILD_DIR/package.json --override-major-version=0 --dapi-branch=$DAPI_BRANCH --drive-branch=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} --drive-slug=${TRAVIS_PULL_REQUEST_SLUG:-TRAVIS_REPO_SLUG}
   - cd $TRAVIS_BUILD_DIR
 
 script: >

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 
 before_script:
   - print-bells
-  - source ./bin/start-local-node.sh $TRAVIS_BUILD_DIR/package.json --override-major-version=0 --dapi-branch=$DAPI_BRANCH --drive-branch=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} --drive-slug=${TRAVIS_PULL_REQUEST_SLUG:-TRAVIS_REPO_SLUG}
+  - source ./bin/start-local-node.sh $TRAVIS_BUILD_DIR/package.json --override-major-version=0 --dapi-branch=$DAPI_BRANCH --drive-branch=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} --drive-repo-slug=${TRAVIS_PULL_REQUEST_SLUG:-TRAVIS_REPO_SLUG}
   - cd $TRAVIS_BUILD_DIR
 
 script: >


### PR DESCRIPTION
This PR should work with [this change](https://github.com/dashevo/travis-ci-tools/pull/9) to the travis-ci-tools to allow tests to run on pull requests from external repos.

## Issue being fixed or feature implemented
I am trying to [contribute](https://github.com/dashevo/js-drive/pull/414) to js-drive but the tests assume the PR is from inside the same repo. This should allow it to work from other repos as well.

## What was done?
Passed travis env variable to travis-ci-tools script

## How Has This Been Tested?
This has not been tested and I don't know how to test it.

## Breaking Changes
Maybe the same thing should be done for DAPI?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
