### PR TITLE
fix: hash was used as a Buffer where it should be hex string

### DIFF
--- a/lib/core/ensureBlock.js
+++ b/lib/core/ensureBlock.js
@@ -10,7 +10,7 @@ const ZMQClient = require('@dashevo/dashd-zmq');
 async function ensureBlock(zmqClient, rpcClient, hash) {
   const eventPromise = new Promise((resolve) => {
     const onHashBlock = (response) => {
-      if (hash === response) {
+      if (hash.toString('hex') === response.toString('hex')) {
         zmqClient.removeListener(ZMQClient.TOPICS.hashblock, onHashBlock);
 
         resolve(response);
@@ -21,7 +21,7 @@ async function ensureBlock(zmqClient, rpcClient, hash) {
   });
 
   try {
-    await rpcClient.getBlock(hash);
+    await rpcClient.getBlock(hash.toString('hex'));
   } catch (e) {
     // Block not found
     if (e.code === -5) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue with chain lock `hash` being passed as a `Buffer`

## What was done?
<!--- Describe your changes in detail -->
- Used `.toString('hex')`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
