### PR TITLE
feat!: add masternode info to ResponseInfo

### DIFF
--- a/lib/abci/handlers/infoHandlerFactory.js
+++ b/lib/abci/handlers/infoHandlerFactory.js
@@ -11,11 +11,12 @@ const { asValue } = require('awilix');
 const { version: driveVersion } = require('../../../package');
 
 /**
- * @param {ChainInfo} chainInfo
+ * @param {ChainInfo} chainInfoRepository
  * @param {Number} protocolVersion
  * @param {RootTree} rootTree
  * @param {updateSimplifiedMasternodeList} updateSimplifiedMasternodeList
  * @param {BaseLogger} logger
+ * @param {container} container
  * @return {infoHandler}
  */
 function infoHandlerFactory(

--- a/lib/abci/handlers/infoHandlerFactory.js
+++ b/lib/abci/handlers/infoHandlerFactory.js
@@ -39,6 +39,13 @@ function infoHandlerFactory(
   async function infoHandler() {
     logger.debug('Tenderdash requests Info');
 
+    const mnStatus = await getMasternodeInfo();
+
+    if (!mnStatus.proTxHash) {
+      logger.debug('infoHandler: masternode status returned no proTxHash');
+      throw new Error('infoHandler: masternode status returned no proTxHash');
+    }
+
     const chainInfo = await chainInfoRepository.fetch();
 
     container.register({
@@ -62,6 +69,7 @@ function infoHandlerFactory(
       appVersion: protocolVersion,
       lastBlockHeight: chainInfo.getLastBlockHeight(),
       lastBlockAppHash: rootTree.getRootHash(),
+      //proTxHash: mnStatus.proTxHash, TODO: active when tendermint.abci.ResponseInfo is ready
     });
   }
 

--- a/lib/abci/handlers/infoHandlerFactory.js
+++ b/lib/abci/handlers/infoHandlerFactory.js
@@ -15,6 +15,7 @@ const { version: driveVersion } = require('../../../package');
  * @param {Number} protocolVersion
  * @param {RootTree} rootTree
  * @param {updateSimplifiedMasternodeList} updateSimplifiedMasternodeList
+ * @param {getMasternodeInfo} getMasternodeInfo
  * @param {BaseLogger} logger
  * @param {container} container
  * @return {infoHandler}
@@ -24,6 +25,7 @@ function infoHandlerFactory(
   protocolVersion,
   rootTree,
   updateSimplifiedMasternodeList,
+  getMasternodeInfo,
   logger,
   container,
 ) {

--- a/lib/core/getMasternodeInfoFactory.js
+++ b/lib/core/getMasternodeInfoFactory.js
@@ -1,0 +1,34 @@
+/**
+ * Gets masternode info (factory)
+ *
+ * @param {RpcClient} coreRpcClient
+ * @param {BaseLogger} logger
+ * @returns {getMasternodeInfo}
+ */
+function getMasternodeInfoFactory(coreRpcClient, logger) {
+  /**
+   * Gets masternode info
+   * by calling DashCore's quorum info rpc cmd
+   *
+   * @typedef getMasternodeInfo
+   *
+   * @returns {Promise<Object>}
+   */
+  async function getMasternodeInfo() {
+    try {
+      return await coreRpcClient.masternode('status');
+    } catch (e) {
+      // This is not a masternode
+      if (e.code === -32603) {
+        logger.error(`getMasternodeInfo: ${e.message}`);
+      } else {
+        logger.error(`getMasternodeInfo: Unknown masternode status error ${e}`);
+      }
+      throw e;
+    }
+  }
+
+  return getMasternodeInfo;
+}
+
+module.exports = getMasternodeInfoFactory;

--- a/lib/createDIContainer.js
+++ b/lib/createDIContainer.js
@@ -108,6 +108,7 @@ const updateSimplifiedMasternodeListFactory = require('./core/updateSimplifiedMa
 const waitForChainLockedHeightFactory = require('./core/waitForChainLockedHeightFactory');
 const SimplifiedMasternodeList = require('./core/SimplifiedMasternodeList');
 const decodeChainLock = require('./core/decodeChainLock');
+const getMasternodeInfoFactory = require('./core/getMasternodeInfoFactory');
 const populateMongoDbTransactionFromObjectFactory = require('./document/populateMongoDbTransactionFromObjectFactory');
 
 const FileDb = require('./fileDb/FileDb');
@@ -275,6 +276,7 @@ async function createDIContainer(options) {
     latestCoreChainLock: asValue(new LatestCoreChainLock()),
     simplifiedMasternodeList: asClass(SimplifiedMasternodeList).proxy().singleton(),
     decodeChainLock: asValue(decodeChainLock),
+    getMasternodeInfo: asFunction(getMasternodeInfoFactory).singleton(),
   });
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,9 +302,8 @@
       }
     },
     "@dashevo/abci": {
-      "version": "0.17.0-dev.3",
-      "resolved": "https://registry.npmjs.org/@dashevo/abci/-/abci-0.17.0-dev.3.tgz",
-      "integrity": "sha512-ELu3B2a8UBqk7ZF+xUR69vRpSbinCb7sBSjVEK4ajTES/LyITaOd3ZTV5Ezz701/IYO2gtlRR9b+xa61Z/wLmg==",
+      "version": "github:dashevo/js-abci#de53ee5a8e4634e696a0356aeae0ad4e597bf936",
+      "from": "github:dashevo/js-abci#signing",
       "requires": {
         "bl": "^1.2.3",
         "debug": "^3.1.0",
@@ -371,9 +370,9 @@
       }
     },
     "@dashevo/dashcore-lib": {
-      "version": "0.19.16",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.19.16.tgz",
-      "integrity": "sha512-mSS1+CrL7cDuMRtUsHqd0YCl4OfbzNB0WtfZx4EqLjrawEp22MpCynlTIad10SSgzHS8zfUbk8W7a20AThUc9A==",
+      "version": "0.19.17",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.19.17.tgz",
+      "integrity": "sha512-fby3HwpqLoli6IQxbO+MngllmRcTCU5/Tp9N9x7LwTjcUADEqiLUGzG5qjsGjxB7Rxju1zJmiNn+BLM81Jfp0Q==",
       "requires": {
         "@dashevo/x11-hash-js": "^1.0.2",
         "@types/node": "^12.12.47",
@@ -400,9 +399,8 @@
       }
     },
     "@dashevo/dashd-rpc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-2.0.2.tgz",
-      "integrity": "sha512-fbD+40fzVLHGliRoNd8kGqkoUkGeEKZOo2X5OhEkrUxDoGXTWRL4u0R/e72l57Oj8Aqfwh2S4dQ5gB7zu3AFhA==",
+      "version": "github:dashevo/dashd-rpc#6c85c8ce4a6c55e260f5e90e6b6009841e913381",
+      "from": "github:dashevo/dashd-rpc#quorumInfo",
       "requires": {
         "async": "^3.2.0",
         "bluebird": "^3.7.2"

--- a/package.json
+++ b/package.json
@@ -65,12 +65,12 @@
     "sinon-chai": "^3.5.0"
   },
   "dependencies": {
-    "@dashevo/dashcore-lib": "~0.19.16",
-    "@dashevo/dashd-rpc": "^2.0.2",
+    "@dashevo/abci": "github:dashevo/js-abci#signing",
+    "@dashevo/dashcore-lib": "~0.19.17",
+    "@dashevo/dashd-rpc": "github:dashevo/dashd-rpc#quorumInfo",
     "@dashevo/dashd-zmq": "^1.2.0",
     "@dashevo/dpp": "~0.17.0-dev.8",
     "@dashevo/merk": "github:dashevo/node-merk",
-    "@dashevo/abci": "^0.17.0-dev.3",
     "ajv": "^6.10.0",
     "ajv-keywords": "^3.5.2",
     "awilix": "^4.2.5",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adds masternode info to ResponseInfo  in info handler
Currently blocked because tendermint.abci.ResponseInfo is not yet updated in js-abci and
pubKeys of secret key shares are not available for all nodes.

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
