### PR TITLE
fix: duplicate MongoDB index name

### DIFF
--- a/lib/document/mongoDbRepository/convertToMongoDbIndices.js
+++ b/lib/document/mongoDbRepository/convertToMongoDbIndices.js
@@ -21,7 +21,6 @@ function convertToMongoDbIndices(indices) {
     return {
       key,
       unique: !!index.unique,
-      name: Object.keys(key).join('_'),
     };
   });
 }

--- a/test/unit/document/mongoDbRepository/convertToMongoDbIndices.spec.js
+++ b/test/unit/document/mongoDbRepository/convertToMongoDbIndices.spec.js
@@ -36,21 +36,18 @@ describe('convertToMongoDbIndices', () => {
         'data.firstName': -1,
       },
       unique: true,
-      name: 'ownerId_data.firstName',
     }, {
       key: {
         ownerId: 1,
         'data.lastName': -1,
       },
       unique: false,
-      name: 'ownerId_data.lastName',
     }, {
       key: {
         _id: 1,
         'data.lastName': -1,
       },
       unique: false,
-      name: '_id_data.lastName',
     }]);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Document indices on the same properties but with different direction produces the same index name that leads to "Index must have unique name" error

## What was done?
<!--- Describe your changes in detail -->
Removed the `name` option to let MongoDB generate a default unique name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
