### PR TITLE
fix: logger with context is not used in some cases

### DIFF
--- a/lib/abci/handlers/commitHandlerFactory.js
+++ b/lib/abci/handlers/commitHandlerFactory.js
@@ -199,9 +199,9 @@ function commitHandlerFactory(
 
     consensusLogger.info(
       {
-        appHash: appHash.toString('hex'),
+        appHash: appHash.toString('hex').toUpperCase(),
       },
-      `Block commit #${blockHeight} with appHash ${appHash.toString('hex')}`,
+      `Block commit #${blockHeight} with appHash ${appHash.toString('hex').toUpperCase()}`,
     );
 
     return new ResponseCommit({

--- a/lib/abci/handlers/deliverTxHandlerFactory.js
+++ b/lib/abci/handlers/deliverTxHandlerFactory.js
@@ -50,7 +50,8 @@ function deliverTxHandlerFactory(
       .createHash('sha256')
       .update(stateTransitionByteArray)
       .digest()
-      .toString('hex');
+      .toString('hex')
+      .toUpperCase();
 
     const consensusLogger = logger.child({
       height: blockHeight.toString(),

--- a/lib/abci/handlers/infoHandlerFactory.js
+++ b/lib/abci/handlers/infoHandlerFactory.js
@@ -11,11 +11,12 @@ const { asValue } = require('awilix');
 const { version: driveVersion } = require('../../../package');
 
 /**
- * @param {ChainInfo} chainInfo
+ * @param {ChainInfoRepository} chainInfoRepository
  * @param {Number} protocolVersion
  * @param {RootTree} rootTree
  * @param {updateSimplifiedMasternodeList} updateSimplifiedMasternodeList
  * @param {BaseLogger} logger
+ * @param {AwilixContainer} container
  * @return {infoHandler}
  */
 function infoHandlerFactory(
@@ -57,7 +58,9 @@ function infoHandlerFactory(
     if (chainInfo.getLastBlockHeight().gt(0)) {
       const lastCoreChainLockedHeight = chainInfo.getLastCoreChainLockedHeight();
 
-      await updateSimplifiedMasternodeList(lastCoreChainLockedHeight);
+      await updateSimplifiedMasternodeList(lastCoreChainLockedHeight, {
+        logger: contextLogger,
+      });
     }
 
     const appHash = rootTree.getRootHash();
@@ -65,9 +68,9 @@ function infoHandlerFactory(
     contextLogger.info(
       {
         ...chainInfo.toJSON(),
-        appHash,
+        appHash: appHash.toString('hex'),
       },
-      `Start processing on block #${chainInfo.getLastBlockHeight()} with appHash ${appHash.toString('hex')}`,
+      `Start processing from block #${chainInfo.getLastBlockHeight()} with appHash ${appHash.toString('hex') || 'nil'}`,
     );
 
     return new ResponseInfo({

--- a/lib/abci/handlers/infoHandlerFactory.js
+++ b/lib/abci/handlers/infoHandlerFactory.js
@@ -68,9 +68,9 @@ function infoHandlerFactory(
     contextLogger.info(
       {
         ...chainInfo.toJSON(),
-        appHash: appHash.toString('hex'),
+        appHash: appHash.toString('hex').toUpperCase(),
       },
-      `Start processing from block #${chainInfo.getLastBlockHeight()} with appHash ${appHash.toString('hex') || 'nil'}`,
+      `Start processing from block #${chainInfo.getLastBlockHeight()} with appHash ${appHash.toString('hex').toUpperCase() || 'nil'}`,
     );
 
     return new ResponseInfo({

--- a/lib/abci/handlers/initChainHandlerFactory.js
+++ b/lib/abci/handlers/initChainHandlerFactory.js
@@ -35,7 +35,9 @@ function initChainHandlerFactory(
     contextLogger.debug('InitChain ABCI method requested');
     contextLogger.trace({ request });
 
-    await updateSimplifiedMasternodeList(initialCoreChainLockedHeight);
+    await updateSimplifiedMasternodeList(initialCoreChainLockedHeight, {
+      logger: contextLogger,
+    });
 
     contextLogger.info(`Init ${request.chainId} chain on block #${request.initialHeight.toString()}`);
 

--- a/test/unit/abci/handlers/infoHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/infoHandlerFactory.spec.js
@@ -104,6 +104,9 @@ describe('infoHandlerFactory', () => {
 
     expect(updateSimplifiedMasternodeListMock).to.be.calledOnceWithExactly(
       lastCoreChainLockedHeight,
+      {
+        logger: loggerMock,
+      },
     );
   });
 });

--- a/test/unit/abci/handlers/initChainHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/initChainHandlerFactory.spec.js
@@ -15,13 +15,14 @@ describe('initChainHandlerFactory', () => {
   let initChainHandler;
   let updateSimplifiedMasternodeListMock;
   let initialCoreChainLockedHeight;
+  let loggerMock;
 
   beforeEach(function beforeEach() {
     initialCoreChainLockedHeight = 1;
 
     updateSimplifiedMasternodeListMock = this.sinon.stub();
 
-    const loggerMock = new LoggerMock(this.sinon);
+    loggerMock = new LoggerMock(this.sinon);
 
     initChainHandler = initChainHandlerFactory(
       updateSimplifiedMasternodeListMock,
@@ -40,7 +41,11 @@ describe('initChainHandlerFactory', () => {
 
     expect(updateSimplifiedMasternodeListMock).to.be.calledOnceWithExactly(
       initialCoreChainLockedHeight,
+      {
+        logger: loggerMock,
+      },
     );
+
     expect(response).to.be.an.instanceOf(ResponseInitChain);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Logger with context is not used in `updateSimplifiedMasternodeList` in some cases

## What was done?
<!--- Describe your changes in detail -->
- Pass logger with context to `updateSimplifiedMasternodeList` in all cases
- Stringify `appHash` in logger info object

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
