### PR TITLE
fix: could not resolve `previousBlockExecutionStoreTransactions` on query

### DIFF
--- a/lib/abci/errors/AbciError.js
+++ b/lib/abci/errors/AbciError.js
@@ -62,6 +62,7 @@ AbciError.CODES = {
   INSUFFICIENT_FUNDS: 4,
   EXECUTION_TIMED_OUT: 5,
   MEMORY_LIMIT_EXCEEDED: 6,
+  UNAVAILABLE: 7,
 };
 
 module.exports = AbciError;

--- a/lib/abci/errors/UnavailableAbciError.js
+++ b/lib/abci/errors/UnavailableAbciError.js
@@ -1,0 +1,12 @@
+const AbciError = require('./AbciError');
+
+class UnavailableAbciError extends AbciError {
+  constructor() {
+    super(
+      AbciError.CODES.UNAVAILABLE,
+      'The service is currently unavailable',
+    );
+  }
+}
+
+module.exports = UnavailableAbciError;

--- a/lib/abci/handlers/commitHandlerFactory.js
+++ b/lib/abci/handlers/commitHandlerFactory.js
@@ -8,7 +8,6 @@ const {
 
 const Long = require('long');
 const { asValue } = require('awilix');
-const NoPreviousBlockExecutionStoreTransactionsFoundError = require('./errors/NoPreviousBlockExecutionStoreTransactionsFoundError');
 const DataCorruptedError = require('./errors/DataCorruptedError');
 
 /**
@@ -68,29 +67,6 @@ function commitHandlerFactory(
 
     consensusLogger.debug('Commit ABCI method requested');
 
-    // If the current block is higher than 1 we need to obtain previous block data
-    let previousBlockExecutionStoreTransactions;
-    if (blockHeight > 1) {
-      if (container.has('previousBlockExecutionStoreTransactions')) {
-        previousBlockExecutionStoreTransactions = container.resolve(
-          'previousBlockExecutionStoreTransactions',
-        );
-      } else {
-        // If container doesn't have previous transactions, load them from file (node cold start)
-        previousBlockExecutionStoreTransactions = (
-          await previousBlockExecutionStoreTransactionsRepository.fetch()
-        );
-
-        if (!previousBlockExecutionStoreTransactions) {
-          throw new NoPreviousBlockExecutionStoreTransactionsFoundError();
-        }
-
-        container.register({
-          previousBlockExecutionStoreTransactions: asValue(previousBlockExecutionStoreTransactions),
-        });
-      }
-    }
-
     let nextPreviousBlockExecutionStoreTransactions;
     try {
       // Create document databases for dataContracts created in the current block
@@ -138,6 +114,10 @@ function commitHandlerFactory(
     rootTree.rebuild();
 
     // Commit previous block data to previous stores
+    const previousBlockExecutionStoreTransactions = container.resolve(
+      'previousBlockExecutionStoreTransactions',
+    );
+
     if (previousBlockExecutionStoreTransactions) {
       // Create document databases in previous dbs
       const previousDataContractTransaction = previousBlockExecutionStoreTransactions.getTransaction('dataContracts');

--- a/lib/abci/handlers/commitHandlerFactory.js
+++ b/lib/abci/handlers/commitHandlerFactory.js
@@ -113,12 +113,12 @@ function commitHandlerFactory(
     // rebuild root tree with committed data from the current block
     rootTree.rebuild();
 
-    // Commit previous block data to previous stores
-    const previousBlockExecutionStoreTransactions = container.resolve(
-      'previousBlockExecutionStoreTransactions',
-    );
+    // Commit previous block data to previous stores if available
+    if (container.has('previousBlockExecutionStoreTransactions')) {
+      const previousBlockExecutionStoreTransactions = container.resolve(
+        'previousBlockExecutionStoreTransactions',
+      );
 
-    if (previousBlockExecutionStoreTransactions) {
       // Create document databases in previous dbs
       const previousDataContractTransaction = previousBlockExecutionStoreTransactions.getTransaction('dataContracts');
       const { updates: previousCreatedDataContracts } = previousDataContractTransaction.toObject();

--- a/lib/abci/handlers/infoHandlerFactory.js
+++ b/lib/abci/handlers/infoHandlerFactory.js
@@ -8,14 +8,19 @@ const {
 
 const { asValue } = require('awilix');
 
+const NoPreviousBlockExecutionStoreTransactionsFoundError = require('./errors/NoPreviousBlockExecutionStoreTransactionsFoundError');
+
 const { version: driveVersion } = require('../../../package');
 
 /**
- * @param {ChainInfoRepository} chainInfoRepository
+ * @param {ChainInfoExternalStoreRepository} chainInfoRepository
  * @param {Number} protocolVersion
  * @param {RootTree} rootTree
  * @param {updateSimplifiedMasternodeList} updateSimplifiedMasternodeList
  * @param {BaseLogger} logger
+ * @param {
+ *   PreviousBlockExecutionStoreTransactionsRepository
+ * } previousBlockExecutionStoreTransactionsRepository
  * @param {AwilixContainer} container
  * @return {infoHandler}
  */
@@ -25,6 +30,7 @@ function infoHandlerFactory(
   rootTree,
   updateSimplifiedMasternodeList,
   logger,
+  previousBlockExecutionStoreTransactionsRepository,
   container,
 ) {
   /**
@@ -53,9 +59,25 @@ function infoHandlerFactory(
       height: chainInfo.getLastBlockHeight().toString(),
     });
 
-    // Update SML store to latest saved core chain lock to make sure
-    // that verfy chain lock handler has updated SML Store to verify signatures
     if (chainInfo.getLastBlockHeight().gt(0)) {
+      // If the current block is higher than 1 we need to obtain previous block data
+      if (!container.has('previousBlockExecutionStoreTransactions')) {
+        // If container doesn't have previous transactions, load them from file (node cold start)
+        const previousBlockExecutionStoreTransactions = (
+          await previousBlockExecutionStoreTransactionsRepository.fetch()
+        );
+
+        if (!previousBlockExecutionStoreTransactions) {
+          throw new NoPreviousBlockExecutionStoreTransactionsFoundError();
+        }
+
+        container.register({
+          previousBlockExecutionStoreTransactions: asValue(previousBlockExecutionStoreTransactions),
+        });
+      }
+
+      // Update SML store to latest saved core chain lock to make sure
+      // that verfy chain lock handler has updated SML Store to verify signatures
       const lastCoreChainLockedHeight = chainInfo.getLastCoreChainLockedHeight();
 
       await updateSimplifiedMasternodeList(lastCoreChainLockedHeight, {

--- a/lib/abci/handlers/query/documentQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/documentQueryHandlerFactory.js
@@ -10,18 +10,21 @@ const cbor = require('cbor');
 
 const InvalidQueryError = require('../../../document/errors/InvalidQueryError');
 const InvalidArgumentAbciError = require('../../errors/InvalidArgumentAbciError');
+const UnavailableAbciError = require('../../errors/UnavailableAbciError');
 
 /**
  *
  * @param {fetchDocuments} fetchPreviousDocuments
  * @param {RootTree} previousRootTree
  * @param {DocumentsStoreRootTreeLeaf} previousDocumentsStoreRootTreeLeaf
+ * @param {AwilixContainer} container
  * @return {documentQueryHandler}
  */
 function documentQueryHandlerFactory(
   fetchPreviousDocuments,
   previousRootTree,
   previousDocumentsStoreRootTreeLeaf,
+  container,
 ) {
   /**
    * @typedef documentQueryHandler
@@ -51,6 +54,10 @@ function documentQueryHandlerFactory(
     },
     request,
   ) {
+    if (!container.has('previousBlockExecutionStoreTransactions')) {
+      throw new UnavailableAbciError();
+    }
+
     let documents;
 
     try {

--- a/lib/core/detectStandaloneRegtestModeFactory.js
+++ b/lib/core/detectStandaloneRegtestModeFactory.js
@@ -21,6 +21,7 @@ function detectStandaloneRegtestModeFactory(coreRpcClient) {
     }
 
     const { result: blockchainInfo } = await coreRpcClient.getBlockchainInfo();
+
     if (blockchainInfo.chain === 'regtest') {
       // wait for core to connect to peers
       await wait(5000);

--- a/test/unit/abci/handlers/commitHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/commitHandlerFactory.spec.js
@@ -96,6 +96,7 @@ describe('commitHandlerFactory', () => {
     containerMock = {
       register: this.sinon.stub(),
       resolve: this.sinon.stub(),
+      has: this.sinon.stub(),
     };
 
     const loggerMock = new LoggerMock(this.sinon);
@@ -149,6 +150,8 @@ describe('commitHandlerFactory', () => {
   });
 
   it('should commit db transactions, update chain info, create document dbs and return ResponseCommit', async () => {
+    containerMock.has.withArgs('previousBlockExecutionStoreTransactions').returns(false);
+
     const response = await commitHandler();
 
     expect(response).to.be.an.instanceOf(ResponseCommit);
@@ -187,10 +190,12 @@ describe('commitHandlerFactory', () => {
     );
   });
 
-  it('should commit db transactions, update chain info, create document dbs and return ResponseCommit ion height > 1', async () => {
+  it('should commit db transactions, update chain info, create document dbs and return ResponseCommit on height > 1', async () => {
     blockExecutionContextMock.getHeader.returns({
       height: 2,
     });
+
+    containerMock.has.withArgs('previousBlockExecutionStoreTransactions').returns(true);
 
     containerMock.resolve.withArgs('previousBlockExecutionStoreTransactions').returns(
       previousBlockExecutionStoreTransactionsMock,
@@ -254,9 +259,7 @@ describe('commitHandlerFactory', () => {
       height: 2,
     });
 
-    previousBlockExecutionStoreTransactionsRepositoryMock.fetch.resolves(
-      previousBlockExecutionStoreTransactionsMock,
-    );
+    containerMock.has.withArgs('previousBlockExecutionStoreTransactionsMock').returns(true);
 
     previousBlockExecutionStoreTransactionsMock.getTransaction.withArgs('dataContracts').returns(
       previousDataContractTransactionMock,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Could not resolve `previousBlockExecutionStoreTransactions` error thrown on query happened before any blocks are processed.

## What was done?
<!--- Describe your changes in detail -->
- Fetch and register `previousBlockExecutionStoreTransactions` moved from commit to info handler.
- Respond with `UnavailableAbciError` if `previousBlockExecutionStoreTransactions` is not present on query

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
