### PR TITLE
fix: blockExecutionContext header might be null

### DIFF
--- a/lib/dpp/DriveStateRepository.js
+++ b/lib/dpp/DriveStateRepository.js
@@ -239,7 +239,12 @@ class DriveStateRepository {
    * @return {Promise<boolean>}
    */
   async verifyInstantLock(instantLock) {
-    const { coreChainLockedHeight } = this.blockExecutionContext.getHeader();
+    const header = this.blockExecutionContext.getHeader();
+
+    let coreChainLockedHeight;
+    if (header) {
+      ({ coreChainLockedHeight } = header);
+    }
 
     try {
       const { result: isVerified } = await this.coreRpcClient.verifyIsLock(

--- a/test/unit/dpp/DriveStateRepository.spec.js
+++ b/test/unit/dpp/DriveStateRepository.spec.js
@@ -383,5 +383,23 @@ describe('DriveStateRepository', () => {
         42,
       );
     });
+
+    it('should return false if header is null', async () => {
+      blockExecutionContextMock.getHeader.resolves(null);
+
+      const error = new Error('Some error');
+      error.code = -8;
+
+      coreRpcClientMock.verifyIsLock.throws(error);
+
+      const result = await stateRepository.verifyInstantLock(instantLockMock);
+      expect(result).to.equal(false);
+      expect(coreRpcClientMock.verifyIsLock).to.have.been.calledOnceWithExactly(
+        'someRequestId',
+        'someTxId',
+        'signature',
+        undefined,
+      );
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DriveStateRepository verifyInstantLock throws fatal error if blockExecutionContext header is null 

## What was done?
<!--- Describe your changes in detail -->
Fix fatal error when blockExecutionContext header is null

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
