### PR TITLE
fix: documents were deleted using wrong id

### DIFF
--- a/lib/document/populateMongoDbTransactionFromObjectFactory.js
+++ b/lib/document/populateMongoDbTransactionFromObjectFactory.js
@@ -36,7 +36,7 @@ function populateMongoDbTransactionFromObjectFactory(
       });
 
     const deleteOperations = Object.entries(transactionObject.deletes)
-      .map(async ([documentId, serializedDocument]) => {
+      .map(async ([, serializedDocument]) => {
         const document = await dpp.document.createFromBuffer(serializedDocument, {
           skipValidation: true,
         });
@@ -46,7 +46,7 @@ function populateMongoDbTransactionFromObjectFactory(
           document.getType(),
         );
 
-        return mongoDbRepository.delete(documentId, transaction);
+        return mongoDbRepository.delete(document.getId(), transaction);
       });
 
     await Promise.all(updateOperations.concat(deleteOperations));

--- a/test/unit/document/populateMongoDbTransactionFromObjectFactory.spec.js
+++ b/test/unit/document/populateMongoDbTransactionFromObjectFactory.spec.js
@@ -100,7 +100,7 @@ describe('populateMongoDbTransactionFromObjectFactory', () => {
       transactionMock,
     );
     expect(mongoDbRepositoryMock.delete).to.be.calledOnceWithExactly(
-      'documentIdToDelete',
+      documentToDelete.getId(),
       transactionMock,
     );
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Delete query for MongoDB was constructed using wrong hex version of document id instead of `Identifier` 

## What was done?
<!--- Describe your changes in detail -->
- construct query using `document.getId()`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local env

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
