### PR TITLE
fix: unavailable error until the second block committed

### DIFF
--- a/lib/abci/handlers/query/dataContractQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/dataContractQueryHandlerFactory.js
@@ -42,7 +42,7 @@ function dataContractQueryHandlerFactory(
    * @return {Promise<ResponseQuery>}
    */
   async function dataContractQueryHandler(params, { id }, request) {
-    // There is no signed state (we are on block 1)
+    // There is no signed state (current committed block height less then 2)
     if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
       throw new NotFoundAbciError('Data Contract not found');
     }

--- a/lib/abci/handlers/query/dataContractQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/dataContractQueryHandlerFactory.js
@@ -20,6 +20,8 @@ const NotFoundAbciError = require('../../errors/NotFoundAbciError');
  * @param {RootTree} previousRootTree
  * @param {DataContractsStoreRootTreeLeaf} previousDataContractsStoreRootTreeLeaf
  * @param {createQueryResponse} createQueryResponse
+ * @param {BlockExecutionContext} blockExecutionContext
+ * @param {BlockExecutionContext} previousBlockExecutionContext
  * @return {dataContractQueryHandler}
  */
 function dataContractQueryHandlerFactory(
@@ -27,6 +29,8 @@ function dataContractQueryHandlerFactory(
   previousRootTree,
   previousDataContractsStoreRootTreeLeaf,
   createQueryResponse,
+  blockExecutionContext,
+  previousBlockExecutionContext,
 ) {
   /**
    * @typedef dataContractQueryHandler
@@ -38,6 +42,11 @@ function dataContractQueryHandlerFactory(
    * @return {Promise<ResponseQuery>}
    */
   async function dataContractQueryHandler(params, { id }, request) {
+    // There is no signed state (we are on block 1)
+    if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
+      throw new NotFoundAbciError('Data Contract not found');
+    }
+
     const isProofRequested = request.prove === 'true';
 
     const response = createQueryResponse(GetDataContractResponse, isProofRequested);

--- a/lib/abci/handlers/query/documentQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/documentQueryHandlerFactory.js
@@ -23,6 +23,8 @@ const UnavailableAbciError = require('../../errors/UnavailableAbciError');
  * @param {DocumentsStoreRootTreeLeaf} previousDocumentsStoreRootTreeLeaf
  * @param {AwilixContainer} container
  * @param {createQueryResponse} createQueryResponse
+ * @param {BlockExecutionContext} blockExecutionContext
+ * @param {BlockExecutionContext} previousBlockExecutionContext
  * @return {documentQueryHandler}
  */
 function documentQueryHandlerFactory(
@@ -31,6 +33,8 @@ function documentQueryHandlerFactory(
   previousDocumentsStoreRootTreeLeaf,
   container,
   createQueryResponse,
+  blockExecutionContext,
+  previousBlockExecutionContext,
 ) {
   /**
    * @typedef documentQueryHandler
@@ -60,6 +64,15 @@ function documentQueryHandlerFactory(
     },
     request,
   ) {
+    // There is no signed state (we are on block 1)
+    if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
+      const response = new GetDocumentsResponse();
+
+      return new ResponseQuery({
+        value: response.serializeBinary(),
+      });
+    }
+
     if (!container.has('previousBlockExecutionStoreTransactions')) {
       throw new UnavailableAbciError();
     }

--- a/lib/abci/handlers/query/documentQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/documentQueryHandlerFactory.js
@@ -64,7 +64,7 @@ function documentQueryHandlerFactory(
     },
     request,
   ) {
-    // There is no signed state (we are on block 1)
+    // There is no signed state (current committed block height less then 2)
     if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
       const response = new GetDocumentsResponse();
 

--- a/lib/abci/handlers/query/getProofsQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/getProofsQueryHandlerFactory.js
@@ -7,7 +7,6 @@ const {
 } = require('@dashevo/abci/types');
 
 const cbor = require('cbor');
-const UnavailableAbciError = require('../../errors/UnavailableAbciError');
 
 /**
  *
@@ -42,7 +41,13 @@ function getProofsQueryHandlerFactory(
     dataContractIds,
   }) {
     if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
-      throw new UnavailableAbciError();
+      return new ResponseQuery({
+        value: await cbor.encodeAsync({
+          documentsProof: null,
+          identitiesProof: null,
+          dataContractsProof: null,
+        }),
+      });
     }
 
     const {

--- a/lib/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.js
@@ -22,6 +22,8 @@ const InvalidArgumentAbciError = require('../../errors/InvalidArgumentAbciError'
  * @param {RootTree} previousRootTree
  * @param {IdentitiesStoreRootTreeLeaf} previousIdentitiesStoreRootTreeLeaf
  * @param {createQueryResponse} createQueryResponse
+ * @param {BlockExecutionContext} blockExecutionContext
+ * @param {BlockExecutionContext} previousBlockExecutionContext
  * @return {identitiesByPublicKeyHashesQueryHandler}
  */
 function identitiesByPublicKeyHashesQueryHandlerFactory(
@@ -31,6 +33,8 @@ function identitiesByPublicKeyHashesQueryHandlerFactory(
   previousRootTree,
   previousIdentitiesStoreRootTreeLeaf,
   createQueryResponse,
+  blockExecutionContext,
+  previousBlockExecutionContext,
 ) {
   /**
    * @typedef identitiesByPublicKeyHashesQueryHandler
@@ -50,26 +54,25 @@ function identitiesByPublicKeyHashesQueryHandlerFactory(
       );
     }
 
+    // There is no signed state (we are on block 1)
+    if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
+      const response = new GetIdentitiesByPublicKeyHashesResponse();
+
+      response.setIdentitiesList(publicKeyHashes.map(() => Buffer.alloc(0)));
+
+      return new ResponseQuery({
+        value: response.serializeBinary(),
+      });
+    }
+
     const isProofRequested = request.prove === 'true';
 
     const response = createQueryResponse(GetIdentitiesByPublicKeyHashesResponse, isProofRequested);
 
-    const identityIds = [];
-
-    const identityBuffers = await Promise.all(
-      publicKeyHashes.map(async (publicKeyHash) => {
-        const identityId = await previousPublicKeyToIdentityIdRepository.fetch(publicKeyHash);
-
-        if (!identityId) {
-          return Buffer.alloc(0);
-        }
-
-        identityIds.push(identityId);
-
-        const identity = await previousIdentityRepository.fetch(identityId);
-
-        return identity.toBuffer();
-      }),
+    const identityIds = await Promise.all(
+      publicKeyHashes.map((publicKeyHash) => (
+        previousPublicKeyToIdentityIdRepository.fetch(publicKeyHash)
+      )),
     );
 
     if (isProofRequested) {
@@ -78,11 +81,26 @@ function identitiesByPublicKeyHashesQueryHandlerFactory(
       const {
         rootTreeProof,
         storeTreeProof,
-      } = previousRootTree.getFullProof(previousIdentitiesStoreRootTreeLeaf, identityIds);
+      } = previousRootTree.getFullProof(
+        previousIdentitiesStoreRootTreeLeaf,
+        identityIds.filter(Boolean).map((identityId) => identityId.toBuffer()),
+      );
 
       proof.setRootTreeProof(rootTreeProof);
       proof.setStoreTreeProof(storeTreeProof);
     } else {
+      const identityBuffers = await Promise.all(
+        identityIds.map(async (identityId) => {
+          if (!identityId) {
+            return Buffer.alloc(0);
+          }
+
+          const identity = await previousIdentityRepository.fetch(identityId);
+
+          return identity.toBuffer();
+        }),
+      );
+
       response.setIdentitiesList(identityBuffers);
     }
 

--- a/lib/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.js
@@ -54,7 +54,7 @@ function identitiesByPublicKeyHashesQueryHandlerFactory(
       );
     }
 
-    // There is no signed state (we are on block 1)
+    // There is no signed state (current committed block height less then 2)
     if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
       const response = new GetIdentitiesByPublicKeyHashesResponse();
 

--- a/lib/abci/handlers/query/identityIdsByPublicKeyHashesQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/identityIdsByPublicKeyHashesQueryHandlerFactory.js
@@ -52,7 +52,7 @@ function identityIdsByPublicKeyHashesQueryHandlerFactory(
       );
     }
 
-    // There is no signed state (we are on block 1)
+    // There is no signed state (current committed block height less then 2)
     if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
       const response = new GetIdentityIdsByPublicKeyHashesResponse();
 

--- a/lib/abci/handlers/query/identityIdsByPublicKeyHashesQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/identityIdsByPublicKeyHashesQueryHandlerFactory.js
@@ -21,6 +21,8 @@ const InvalidArgumentAbciError = require('../../errors/InvalidArgumentAbciError'
  * @param {RootTree} previousRootTree
  * @param {PublicKeyToIdentityIdStoreRootTreeLeaf} previousPublicKeyToIdentityIdStoreRootTreeLeaf
  * @param {createQueryResponse} createQueryResponse
+ * @param {BlockExecutionContext} blockExecutionContext
+ * @param {BlockExecutionContext} previousBlockExecutionContext
  * @return {identityIdsByPublicKeyHashesQueryHandler}
  */
 function identityIdsByPublicKeyHashesQueryHandlerFactory(
@@ -29,6 +31,8 @@ function identityIdsByPublicKeyHashesQueryHandlerFactory(
   previousRootTree,
   previousPublicKeyToIdentityIdStoreRootTreeLeaf,
   createQueryResponse,
+  blockExecutionContext,
+  previousBlockExecutionContext,
 ) {
   /**
    * @typedef identityIdsByPublicKeyHashesQueryHandler
@@ -48,20 +52,25 @@ function identityIdsByPublicKeyHashesQueryHandlerFactory(
       );
     }
 
+    // There is no signed state (we are on block 1)
+    if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
+      const response = new GetIdentityIdsByPublicKeyHashesResponse();
+
+      response.setIdentityIdsList(publicKeyHashes.map(() => Buffer.alloc(0)));
+
+      return new ResponseQuery({
+        value: response.serializeBinary(),
+      });
+    }
+
     const isProofRequested = request.prove === 'true';
 
     const response = createQueryResponse(GetIdentityIdsByPublicKeyHashesResponse, isProofRequested);
 
-    const identityIdBuffers = await Promise.all(
-      publicKeyHashes.map(async (publicKeyHash) => {
-        const identityId = await previousPublicKeyToIdentityIdRepository.fetch(publicKeyHash);
-
-        if (!identityId) {
-          return Buffer.alloc(0);
-        }
-
-        return identityId.toBuffer();
-      }),
+    const identityIds = await Promise.all(
+      publicKeyHashes.map(async (publicKeyHash) => (
+        previousPublicKeyToIdentityIdRepository.fetch(publicKeyHash)
+      )),
     );
 
     if (isProofRequested) {
@@ -72,12 +81,20 @@ function identityIdsByPublicKeyHashesQueryHandlerFactory(
         storeTreeProof,
       } = previousRootTree.getFullProof(
         previousPublicKeyToIdentityIdStoreRootTreeLeaf,
-        identityIdBuffers,
+        identityIds.filter(Boolean).map((identityId) => identityId.toBuffer()),
       );
 
       proof.setRootTreeProof(rootTreeProof);
       proof.setStoreTreeProof(storeTreeProof);
     } else {
+      const identityIdBuffers = identityIds.map((identityId) => {
+        if (!identityId) {
+          return Buffer.alloc(0);
+        }
+
+        return identityId.toBuffer();
+      });
+
       response.setIdentityIdsList(identityIdBuffers);
     }
 

--- a/lib/abci/handlers/query/identityQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/identityQueryHandlerFactory.js
@@ -42,7 +42,7 @@ function identityQueryHandlerFactory(
    * @return {Promise<ResponseQuery>}
    */
   async function identityQueryHandler(params, { id }, request) {
-    // There is no signed state (we are on block 1)
+    // There is no signed state (current committed block height less then 2)
     if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
       throw new NotFoundAbciError('Identity not found');
     }

--- a/lib/abci/handlers/query/identityQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/identityQueryHandlerFactory.js
@@ -20,6 +20,8 @@ const NotFoundAbciError = require('../../errors/NotFoundAbciError');
  * @param {RootTree} previousRootTree
  * @param {IdentitiesStoreRootTreeLeaf} previousIdentitiesStoreRootTreeLeaf
  * @param {createQueryResponse} createQueryResponse
+ * @param {BlockExecutionContext} blockExecutionContext
+ * @param {BlockExecutionContext} previousBlockExecutionContext
  * @return {identityQueryHandler}
  */
 function identityQueryHandlerFactory(
@@ -27,6 +29,8 @@ function identityQueryHandlerFactory(
   previousRootTree,
   previousIdentitiesStoreRootTreeLeaf,
   createQueryResponse,
+  blockExecutionContext,
+  previousBlockExecutionContext,
 ) {
   /**
    * @typedef identityQueryHandler
@@ -38,6 +42,11 @@ function identityQueryHandlerFactory(
    * @return {Promise<ResponseQuery>}
    */
   async function identityQueryHandler(params, { id }, request) {
+    // There is no signed state (we are on block 1)
+    if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
+      throw new NotFoundAbciError('Identity not found');
+    }
+
     const isProofRequested = request.prove === 'true';
 
     const response = createQueryResponse(GetIdentityResponse, isProofRequested);

--- a/lib/abci/handlers/query/response/createQueryResponseFactory.js
+++ b/lib/abci/handlers/query/response/createQueryResponseFactory.js
@@ -5,8 +5,6 @@ const {
   },
 } = require('@dashevo/dapi-grpc');
 
-const UnavailableAbciError = require('../../../errors/UnavailableAbciError');
-
 /**
  * @param {BlockExecutionContext} blockExecutionContext
  * @param {BlockExecutionContext} previousBlockExecutionContext
@@ -22,10 +20,6 @@ function createQueryResponseFactory(
    * @param {boolean} [prove=false]
    */
   function createQueryResponse(ResponseClass, prove = false) {
-    if (blockExecutionContext.isEmpty() || previousBlockExecutionContext.isEmpty()) {
-      throw new UnavailableAbciError();
-    }
-
     const {
       height: previousBlockHeight,
       coreChainLockedHeight: previousCoreChainLockedHeight,

--- a/test/unit/abci/handlers/query/dataContractQueryHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/query/dataContractQueryHandlerFactory.spec.js
@@ -20,6 +20,7 @@ const dataContractQueryHandlerFactory = require('../../../../../lib/abci/handler
 const NotFoundAbciError = require('../../../../../lib/abci/errors/NotFoundAbciError');
 const AbciError = require('../../../../../lib/abci/errors/AbciError');
 const UnavailableAbciError = require('../../../../../lib/abci/errors/UnavailableAbciError');
+const BlockExecutionContextMock = require('../../../../../lib/test/mock/BlockExecutionContextMock');
 
 describe('dataContractQueryHandlerFactory', () => {
   let dataContractQueryHandler;
@@ -31,6 +32,8 @@ describe('dataContractQueryHandlerFactory', () => {
   let previousDataContractsStoreRootTreeLeafMock;
   let createQueryResponseMock;
   let responseMock;
+  let blockExecutionContextMock;
+  let previousBlockExecutionContextMock;
 
   beforeEach(function beforeEach() {
     dataContract = getDataContractFixture();
@@ -51,17 +54,46 @@ describe('dataContractQueryHandlerFactory', () => {
 
     createQueryResponseMock.returns(responseMock);
 
+    blockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
+    previousBlockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
+
     dataContractQueryHandler = dataContractQueryHandlerFactory(
       previousDataContractRepositoryMock,
       previousRootTreeMock,
       previousDataContractsStoreRootTreeLeafMock,
       createQueryResponseMock,
+      blockExecutionContextMock,
+      previousBlockExecutionContextMock,
     );
 
     params = { };
     data = {
       id: dataContract.getId(),
     };
+  });
+
+  it('should throw NotFoundAbciError if blockExecutionContext is empty', async () => {
+    blockExecutionContextMock.isEmpty.returns(true);
+
+    try {
+      await dataContractQueryHandler(params, data, {});
+
+      expect.fail('should throw NotFoundAbciError');
+    } catch (e) {
+      expect(e).to.be.an.instanceOf(NotFoundAbciError);
+    }
+  });
+
+  it('should throw NotFoundAbciError if previousBlockExecutionContext is empty', async () => {
+    previousBlockExecutionContextMock.isEmpty.returns(true);
+
+    try {
+      await dataContractQueryHandler(params, data, {});
+
+      expect.fail('should throw NotFoundAbciError');
+    } catch (e) {
+      expect(e).to.be.an.instanceOf(NotFoundAbciError);
+    }
   });
 
   it('should return data contract', async () => {

--- a/test/unit/abci/handlers/query/identityQueryHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/query/identityQueryHandlerFactory.spec.js
@@ -20,6 +20,7 @@ const identityQueryHandlerFactory = require('../../../../../lib/abci/handlers/qu
 const NotFoundAbciError = require('../../../../../lib/abci/errors/NotFoundAbciError');
 const AbciError = require('../../../../../lib/abci/errors/AbciError');
 const UnavailableAbciError = require('../../../../../lib/abci/errors/UnavailableAbciError');
+const BlockExecutionContextMock = require('../../../../../lib/test/mock/BlockExecutionContextMock');
 
 describe('identityQueryHandlerFactory', () => {
   let identityQueryHandler;
@@ -31,6 +32,8 @@ describe('identityQueryHandlerFactory', () => {
   let previousIdentitiesStoreRootTreeLeafMock;
   let createQueryResponseMock;
   let responseMock;
+  let blockExecutionContextMock;
+  let previousBlockExecutionContextMock;
 
   beforeEach(function beforeEach() {
     previousIdentityRepositoryMock = {
@@ -50,11 +53,16 @@ describe('identityQueryHandlerFactory', () => {
 
     createQueryResponseMock.returns(responseMock);
 
+    blockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
+    previousBlockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
+
     identityQueryHandler = identityQueryHandlerFactory(
       previousIdentityRepositoryMock,
       previousRootTreeMock,
       previousIdentitiesStoreRootTreeLeafMock,
       createQueryResponseMock,
+      blockExecutionContextMock,
+      previousBlockExecutionContextMock,
     );
 
     identity = getIdentityFixture();
@@ -63,6 +71,30 @@ describe('identityQueryHandlerFactory', () => {
     data = {
       id: identity.getId(),
     };
+  });
+
+  it('should throw NotFoundAbciError if blockExecutionContext is empty', async () => {
+    blockExecutionContextMock.isEmpty.returns(true);
+
+    try {
+      await identityQueryHandler(params, data, {});
+
+      expect.fail('should throw NotFoundAbciError');
+    } catch (e) {
+      expect(e).to.be.an.instanceOf(NotFoundAbciError);
+    }
+  });
+
+  it('should throw NotFoundAbciError if previousBlockExecutionContext is empty', async () => {
+    previousBlockExecutionContextMock.isEmpty.returns(true);
+
+    try {
+      await identityQueryHandler(params, data, {});
+
+      expect.fail('should throw NotFoundAbciError');
+    } catch (e) {
+      expect(e).to.be.an.instanceOf(NotFoundAbciError);
+    }
   });
 
   it('should return serialized identity', async () => {

--- a/test/unit/abci/handlers/query/response/createQueryResponseFactory.spec.js
+++ b/test/unit/abci/handlers/query/response/createQueryResponseFactory.spec.js
@@ -6,7 +6,6 @@ const {
 
 const BlockExecutionContextMock = require('../../../../../../lib/test/mock/BlockExecutionContextMock');
 const createQueryResponseFactory = require('../../../../../../lib/abci/handlers/query/response/createQueryResponseFactory');
-const UnavailableAbciError = require('../../../../../../lib/abci/errors/UnavailableAbciError');
 
 describe('createQueryResponseFactory', () => {
   let blockExecutionContextMock;
@@ -37,30 +36,6 @@ describe('createQueryResponseFactory', () => {
       blockExecutionContextMock,
       previousBlockExecutionContextMock,
     );
-  });
-
-  it('should throw UnavailableAbciError if blockExecutionContext is empty', () => {
-    blockExecutionContextMock.isEmpty.returns(true);
-
-    try {
-      createQueryResponse(GetDataContractResponse);
-
-      expect.fail('should throw UnavailableAbciError');
-    } catch (e) {
-      expect(e).to.be.an.instanceOf(UnavailableAbciError);
-    }
-  });
-
-  it('should throw UnavailableAbciError if previousBlockExecutionContext is empty', () => {
-    previousBlockExecutionContextMock.isEmpty.returns(true);
-
-    try {
-      createQueryResponse(GetDataContractResponse);
-
-      expect.fail('should throw UnavailableAbciError');
-    } catch (e) {
-      expect(e).to.be.an.instanceOf(UnavailableAbciError);
-    }
   });
 
   it('should create a response', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Until Drive reaches the second block, query handlers respond with the unavailable error that leads to problems on client-side (e.g. halting the local network setup process). Logically, until we have signed state (`previousBlockExecutionContext`) there is no data in Drive and we should respond with the not found error or empty response.

## What was done?
<!--- Describe your changes in detail -->
- Respond with the not found error or empty responses if `blockExectionContext` (until the first block is committed) or `previousBlockExecutionContext` (until the second block is committed) are empty.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- With unit tests
- Setting up the local network with dashmate and the updated Drive

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
