### PR TITLE
revert: remove sml instant lock verification in favor of more robust core verification

### DIFF
--- a/lib/dpp/DriveStateRepository.js
+++ b/lib/dpp/DriveStateRepository.js
@@ -1,3 +1,5 @@
+const featureFlagTypes = require('@dashevo/feature-flags-contract/lib/featureFlagTypes');
+
 class DriveStateRepository {
   /**
    * @param {IdentityStoreRepository} identityRepository
@@ -247,29 +249,44 @@ class DriveStateRepository {
   async verifyInstantLock(instantLock) {
     const header = await this.blockExecutionContext.getHeader();
 
-    const {
-      coreChainLockedHeight,
-    } = header;
-
-    try {
-      const { result: isVerified } = await this.coreRpcClient.verifyIsLock(
-        instantLock.getRequestId().toString('hex'),
-        instantLock.txid,
-        instantLock.signature,
+    // Inital block is produced
+    if (header) {
+      const {
+        height: blockHeight,
         coreChainLockedHeight,
+      } = header;
+
+      const verifyLLMQSignaturesWithCoreFeatureFlag = await this.getLatestFeatureFlag(
+        featureFlagTypes.VERIFY_LLMQ_SIGS_WITH_CORE,
+        blockHeight,
+        this.getDBTransaction('documents'),
       );
 
-      return isVerified;
-    } catch (e) {
-      // Invalid address or key error or
-      // Invalid, missing or duplicate parameter
-      // Parse error
-      if ([-8, -5, -32700].includes(e.code)) {
-        return false;
-      }
+      // Use Core RPC to verify signatures
+      if (verifyLLMQSignaturesWithCoreFeatureFlag && verifyLLMQSignaturesWithCoreFeatureFlag.get('enabled')) {
+        try {
+          const { result: isVerified } = await this.coreRpcClient.verifyIsLock(
+            instantLock.getRequestId().toString('hex'),
+            instantLock.txid,
+            instantLock.signature,
+            coreChainLockedHeight,
+          );
 
-      throw e;
+          return isVerified;
+        } catch (e) {
+          // Invalid address or key error or
+          // Invalid, missing or duplicate parameter
+          // Parse error
+          if ([-8, -5, -32700].includes(e.code)) {
+            return false;
+          }
+
+          throw e;
+        }
+      }
     }
+
+    return instantLock.verify(this.simplifiedMasternodeList.getStore());
   }
 
   /**

--- a/test/unit/dpp/DriveStateRepository.spec.js
+++ b/test/unit/dpp/DriveStateRepository.spec.js
@@ -347,7 +347,22 @@ describe('DriveStateRepository', () => {
       simplifiedMasternodeListMock.getStore.returns(smlStore);
     });
 
-    it('it should verify instant lock using Core', async () => {
+    it('should verify instant lock using dashcore-lib', async () => {
+      instantLockMock.verify.resolves(true);
+
+      const result = await stateRepository.verifyInstantLock(instantLockMock);
+
+      expect(result).to.be.true();
+
+      expect(instantLockMock.verify).to.have.been.calledOnceWithExactly(smlStore);
+      expect(coreRpcClientMock.verifyIsLock).to.have.not.been.called();
+    });
+
+    it('it should verify instant lock using Core if feature flag is enabled', async () => {
+      getLatestFeatureFlagMock.resolves({
+        get: () => true,
+      });
+
       coreRpcClientMock.verifyIsLock.resolves({ result: true });
 
       const result = await stateRepository.verifyInstantLock(instantLockMock);
@@ -363,6 +378,10 @@ describe('DriveStateRepository', () => {
     });
 
     it('should return false if core throws Invalid address or key error', async () => {
+      getLatestFeatureFlagMock.resolves({
+        get: () => true,
+      });
+
       const error = new Error('Some error');
       error.code = -5;
 
@@ -381,6 +400,10 @@ describe('DriveStateRepository', () => {
     });
 
     it('should return false if core throws Invalid parameter', async () => {
+      getLatestFeatureFlagMock.resolves({
+        get: () => true,
+      });
+
       const error = new Error('Some error');
       error.code = -8;
 
@@ -396,6 +419,19 @@ describe('DriveStateRepository', () => {
         42,
       );
       expect(instantLockMock.verify).to.have.not.been.called();
+    });
+
+    it('should verify instant lock using dashcore-lib if header is null', async () => {
+      instantLockMock.verify.resolves(true);
+
+      blockExecutionContextMock.getHeader.returns(null);
+
+      const result = await stateRepository.verifyInstantLock(instantLockMock);
+
+      expect(result).to.be.true();
+
+      expect(instantLockMock.verify).to.have.been.calledOnceWithExactly(smlStore);
+      expect(coreRpcClientMock.verifyIsLock).to.have.not.been.called();
     });
   });
 });


### PR DESCRIPTION
Reverts dashevo/js-drive#533