### PR TITLE
fix: prove request param doesn't affect response

### DIFF
--- a/lib/abci/handlers/query/dataContractQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/dataContractQueryHandlerFactory.js
@@ -37,8 +37,7 @@ function dataContractQueryHandlerFactory(
    * @param {Object} params
    * @param {Object} data
    * @param {Buffer} data.id
-   * @param {Object} request
-   * @param {boolean} [request.prove]
+   * @param {RequestQuery} request
    * @return {Promise<ResponseQuery>}
    */
   async function dataContractQueryHandler(params, { id }, request) {
@@ -47,9 +46,7 @@ function dataContractQueryHandlerFactory(
       throw new NotFoundAbciError('Data Contract not found');
     }
 
-    const isProofRequested = request.prove === 'true';
-
-    const response = createQueryResponse(GetDataContractResponse, isProofRequested);
+    const response = createQueryResponse(GetDataContractResponse, request.prove);
 
     const dataContract = await previousDataContractRepository.fetch(id);
 
@@ -57,7 +54,7 @@ function dataContractQueryHandlerFactory(
       throw new NotFoundAbciError('Data Contract not found');
     }
 
-    if (isProofRequested) {
+    if (request.prove) {
       const proof = response.getProof();
 
       const {

--- a/lib/abci/handlers/query/documentQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/documentQueryHandlerFactory.js
@@ -48,8 +48,7 @@ function documentQueryHandlerFactory(
    * @param {string} [data.limit]
    * @param {string} [data.startAfter]
    * @param {string} [data.startAt]
-   * @param {Object} request
-   * @param {boolean} [request.prove]
+   * @param {RequestQuery} request
    * @return {Promise<ResponseQuery>}
    */
   async function documentQueryHandler(
@@ -86,9 +85,7 @@ function documentQueryHandlerFactory(
       throw new UnavailableAbciError();
     }
 
-    const isProofRequested = request.prove === 'true';
-
-    const response = createQueryResponse(GetDocumentsResponse, isProofRequested);
+    const response = createQueryResponse(GetDocumentsResponse, request.prove);
 
     let documents;
 
@@ -111,7 +108,7 @@ function documentQueryHandlerFactory(
       throw e;
     }
 
-    if (isProofRequested) {
+    if (request.prove) {
       const documentIds = documents.map((document) => document.getId());
 
       const proof = response.getProof();

--- a/lib/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.js
@@ -42,8 +42,7 @@ function identitiesByPublicKeyHashesQueryHandlerFactory(
    * @param {Object} params
    * @param {Object} data
    * @param {Buffer[]} data.publicKeyHashes
-   * @param {Object} request
-   * @param {boolean} [request.prove]
+   * @param {RequestQuery} request
    * @return {Promise<ResponseQuery>}
    */
   async function identitiesByPublicKeyHashesQueryHandler(params, { publicKeyHashes }, request) {
@@ -68,9 +67,7 @@ function identitiesByPublicKeyHashesQueryHandlerFactory(
       });
     }
 
-    const isProofRequested = request.prove === 'true';
-
-    const response = createQueryResponse(GetIdentitiesByPublicKeyHashesResponse, isProofRequested);
+    const response = createQueryResponse(GetIdentitiesByPublicKeyHashesResponse, request.prove);
 
     const identityIds = await Promise.all(
       publicKeyHashes.map((publicKeyHash) => (
@@ -78,7 +75,7 @@ function identitiesByPublicKeyHashesQueryHandlerFactory(
       )),
     );
 
-    if (isProofRequested) {
+    if (request.prove) {
       const proof = response.getProof();
 
       const {

--- a/lib/abci/handlers/query/identityIdsByPublicKeyHashesQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/identityIdsByPublicKeyHashesQueryHandlerFactory.js
@@ -40,8 +40,7 @@ function identityIdsByPublicKeyHashesQueryHandlerFactory(
    * @param {Object} params
    * @param {Object} data
    * @param {Buffer[]} data.publicKeyHashes
-   * @param {Object} request
-   * @param {boolean} [request.prove]
+   * @param {RequestQuery} request
    * @return {Promise<ResponseQuery>}
    */
   async function identityIdsByPublicKeyHashesQueryHandler(params, { publicKeyHashes }, request) {
@@ -66,9 +65,7 @@ function identityIdsByPublicKeyHashesQueryHandlerFactory(
       });
     }
 
-    const isProofRequested = request.prove === 'true';
-
-    const response = createQueryResponse(GetIdentityIdsByPublicKeyHashesResponse, isProofRequested);
+    const response = createQueryResponse(GetIdentityIdsByPublicKeyHashesResponse, request.prove);
 
     const identityIds = await Promise.all(
       publicKeyHashes.map(async (publicKeyHash) => (
@@ -76,7 +73,7 @@ function identityIdsByPublicKeyHashesQueryHandlerFactory(
       )),
     );
 
-    if (isProofRequested) {
+    if (request.prove) {
       const proof = response.getProof();
 
       const {

--- a/lib/abci/handlers/query/identityQueryHandlerFactory.js
+++ b/lib/abci/handlers/query/identityQueryHandlerFactory.js
@@ -37,8 +37,7 @@ function identityQueryHandlerFactory(
    * @param {Object} params
    * @param {Object} options
    * @param {Buffer} options.id
-   * @param {Object} request
-   * @param {boolean} [request.prove]
+   * @param {RequestQuery} request
    * @return {Promise<ResponseQuery>}
    */
   async function identityQueryHandler(params, { id }, request) {
@@ -47,9 +46,7 @@ function identityQueryHandlerFactory(
       throw new NotFoundAbciError('Identity not found');
     }
 
-    const isProofRequested = request.prove === 'true';
-
-    const response = createQueryResponse(GetIdentityResponse, isProofRequested);
+    const response = createQueryResponse(GetIdentityResponse, request.prove);
 
     const identity = await previousIdentityRepository.fetch(id);
 
@@ -59,7 +56,7 @@ function identityQueryHandlerFactory(
 
     const identityBuffer = identity.toBuffer();
 
-    if (isProofRequested) {
+    if (request.prove) {
       const proof = response.getProof();
 
       const {

--- a/lib/abci/handlers/queryHandlerFactory.js
+++ b/lib/abci/handlers/queryHandlerFactory.js
@@ -13,7 +13,7 @@ function queryHandlerFactory(queryHandlerRouter, sanitizeUrl) {
    *
    * @typedef queryHandler
    *
-   * @param {Object} request
+   * @param {RequestQuery} request
    * @return {Promise<Object>}
    */
   async function queryHandler(request) {

--- a/test/unit/abci/handlers/query/dataContractQueryHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/query/dataContractQueryHandlerFactory.spec.js
@@ -117,7 +117,7 @@ describe('dataContractQueryHandlerFactory', () => {
     previousDataContractRepositoryMock.fetch.resolves(dataContract);
     previousRootTreeMock.getFullProof.returns(proof);
 
-    const result = await dataContractQueryHandler(params, data, { prove: 'true' });
+    const result = await dataContractQueryHandler(params, data, { prove: true });
 
     expect(previousDataContractRepositoryMock.fetch).to.be.calledOnceWith(data.id);
     expect(result).to.be.an.instanceof(ResponseQuery);

--- a/test/unit/abci/handlers/query/documentQueryHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/query/documentQueryHandlerFactory.spec.js
@@ -163,7 +163,7 @@ describe('documentQueryHandlerFactory', () => {
     fetchPreviousDocumentsMock.resolves(documents);
     previousRootTreeMock.getFullProof.returns(proof);
 
-    const result = await documentQueryHandler(params, data, { prove: 'true' });
+    const result = await documentQueryHandler(params, data, { prove: true });
 
     expect(fetchPreviousDocumentsMock).to.be.calledOnceWith(data.contractId, data.type, options);
     expect(result).to.be.an.instanceof(ResponseQuery);

--- a/test/unit/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.spec.js
@@ -217,7 +217,7 @@ describe('identitiesByPublicKeyHashesQueryHandlerFactory', () => {
 
     previousRootTreeMock.getFullProof.returns(proof);
 
-    const result = await identitiesByPublicKeyHashesQueryHandler(params, data, { prove: 'true' });
+    const result = await identitiesByPublicKeyHashesQueryHandler(params, data, { prove: true });
 
     expect(previousPublicKeyIdentityIdRepositoryMock.fetch.callCount).to.equal(
       publicKeyHashes.length,

--- a/test/unit/abci/handlers/query/identityIdsByPublicKeyHashesQueryHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/query/identityIdsByPublicKeyHashesQueryHandlerFactory.spec.js
@@ -190,7 +190,7 @@ describe('identityIdsByPublicKeyHashesQueryHandlerFactory', () => {
 
     previousRootTreeMock.getFullProof.returns(proof);
 
-    const result = await identityIdsByPublicKeyHashesQueryHandler(params, data, { prove: 'true' });
+    const result = await identityIdsByPublicKeyHashesQueryHandler(params, data, { prove: true });
 
     expect(previousPublicKeyIdentityIdRepositoryMock.fetch.callCount).to.equal(
       publicKeyHashes.length,

--- a/test/unit/abci/handlers/query/identityQueryHandlerFactory.spec.js
+++ b/test/unit/abci/handlers/query/identityQueryHandlerFactory.spec.js
@@ -130,7 +130,7 @@ describe('identityQueryHandlerFactory', () => {
     previousIdentityRepositoryMock.fetch.resolves(identity);
     previousRootTreeMock.getFullProof.returns(proof);
 
-    const result = await identityQueryHandler(params, data, { prove: 'true' });
+    const result = await identityQueryHandler(params, data, { prove: true });
     expect(previousIdentityRepositoryMock.fetch).to.be.calledOnceWith(data.id);
     expect(result).to.be.an.instanceof(ResponseQuery);
     expect(result.code).to.equal(0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`prove` request param doesn't affect response in query endpoints. They supposed to return proofs if `prove` set to `true` 

## What was done?
<!--- Describe your changes in detail -->
- Check for boolean instead of string

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
