### PR TITLE
fix: `getProofs` method was missing from `PublicKeyToIdentityIdStoreRootTreeLeaf` class

### DIFF
--- a/lib/identity/PublicKeyToIdentityIdStoreRootTreeLeaf.js
+++ b/lib/identity/PublicKeyToIdentityIdStoreRootTreeLeaf.js
@@ -18,6 +18,16 @@ class PublicKeyToIdentityIdStoreRootTreeLeaf extends AbstractRootTreeLeaf {
   getHash() {
     return this.publicKeyToIdentityIdStore.getRootHash();
   }
+
+  /**
+   * Get proof for leaf keys
+   *
+   * @param {Array<Buffer>} leafKeys
+   * @return {Buffer}
+   */
+  getProof(leafKeys) {
+    return this.publicKeyToIdentityIdStore.getProof(leafKeys);
+  }
 }
 
 PublicKeyToIdentityIdStoreRootTreeLeaf.INDEX = 2;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`getProofs` method was missing from `PublicKeyToIdentityIdStoreRootTreeLeaf` class

## What was done?
<!--- Describe your changes in detail -->
- fixed that 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local setup

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
