### PR TITLE
feat: use `toNumber` method of `Long` class to set `height` closer to `int64` in Metadata

### DIFF
--- a/lib/abci/handlers/query/response/createQueryResponseFactory.js
+++ b/lib/abci/handlers/query/response/createQueryResponseFactory.js
@@ -28,7 +28,7 @@ function createQueryResponseFactory(
     const response = new ResponseClass();
 
     const metadata = new ResponseMetadata();
-    metadata.setHeight(previousBlockHeight);
+    metadata.setHeight(previousBlockHeight.toNumber());
     metadata.setCoreChainLockedHeight(previousCoreChainLockedHeight);
 
     response.setMetadata(metadata);

--- a/test/unit/abci/handlers/query/response/createQueryResponseFactory.spec.js
+++ b/test/unit/abci/handlers/query/response/createQueryResponseFactory.spec.js
@@ -4,6 +4,8 @@ const {
   },
 } = require('@dashevo/dapi-grpc');
 
+const Long = require('long');
+
 const BlockExecutionContextMock = require('../../../../../../lib/test/mock/BlockExecutionContextMock');
 const createQueryResponseFactory = require('../../../../../../lib/abci/handlers/query/response/createQueryResponseFactory');
 
@@ -19,7 +21,7 @@ describe('createQueryResponseFactory', () => {
     previousBlockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
 
     metadata = {
-      height: 1,
+      height: new Long(1),
       coreChainLockedHeight: 1,
     };
 
@@ -45,7 +47,10 @@ describe('createQueryResponseFactory', () => {
 
     expect(response).to.be.instanceOf(GetDataContractResponse);
 
-    expect(response.getMetadata().toObject()).to.deep.equal(metadata);
+    expect(response.getMetadata().toObject()).to.deep.equal({
+      height: 1,
+      coreChainLockedHeight: 1,
+    });
     expect(response.getProof()).to.undefined();
   });
 
@@ -56,7 +61,10 @@ describe('createQueryResponseFactory', () => {
 
     expect(response).to.be.instanceOf(GetDataContractResponse);
 
-    expect(response.getMetadata().toObject()).to.deep.equal(metadata);
+    expect(response.getMetadata().toObject()).to.deep.equal({
+      height: 1,
+      coreChainLockedHeight: 1,
+    });
 
     expect(response.getProof().toObject()).to.deep.equal({
       signatureLlmqHash: lastCommitInfo.quorumHash.toString('base64'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We were using `uint32` for `height` parameter in `Metadata`

## What was done?
<!--- Describe your changes in detail -->
- using `toNumber` method of a `Long` class

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
