### PR TITLE
fix: consensus logger wasn't set on error

### DIFF
--- a/lib/abci/errors/enrichErrorWithConsensusLoggerFactory.js
+++ b/lib/abci/errors/enrichErrorWithConsensusLoggerFactory.js
@@ -23,7 +23,7 @@ function enrichErrorWithConsensusLoggerFactory(blockExecutionContext) {
       try {
         return await method(request);
       } catch (e) {
-        const consensusLogger = blockExecutionContext.getConsensusLogger();
+        const { consensusLogger } = blockExecutionContext;
 
         if (consensusLogger) {
           e.consensusLogger = consensusLogger;

--- a/lib/abci/handlers/infoHandlerFactory.js
+++ b/lib/abci/handlers/infoHandlerFactory.js
@@ -98,7 +98,6 @@ function infoHandlerFactory(
         lastHeight: lastHeight.toString(),
         lastCoreChainLockedHeight,
         appHash: appHash.toString('hex').toUpperCase(),
-        driveVersion,
         latestProtocolVersion: latestProtocolVersion.toString(),
       },
       `Start processing from block #${lastHeight} with appHash ${appHash.toString('hex').toUpperCase() || 'nil'}`,

--- a/test/unit/abci/errors/enrichErrorWithConsensusLoggerFactory.spec.js
+++ b/test/unit/abci/errors/enrichErrorWithConsensusLoggerFactory.spec.js
@@ -11,7 +11,7 @@ describe('enrichErrorWithConsensusLoggerFactory', () => {
     loggerMock = new LoggerMock(this.sinon);
 
     blockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
-    blockExecutionContextMock.getConsensusLogger.returns(loggerMock);
+    blockExecutionContextMock.consensusLogger = loggerMock;
 
     enrichErrorWithConsensusLogger = enrichErrorWithConsensusLoggerFactory(
       blockExecutionContextMock,
@@ -33,7 +33,6 @@ describe('enrichErrorWithConsensusLoggerFactory', () => {
       expect.fail('should throw an error');
     } catch (e) {
       expect(e).to.equal(error);
-      expect(blockExecutionContextMock.getConsensusLogger).to.be.calledOnceWithExactly();
       expect(e.consensusLogger).to.equal(loggerMock);
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If consensus logger is not set an error leads to another error "Consensus logger was not set".

## What was done?
<!--- Describe your changes in detail -->
- Get consensus logger from block execution context using property
- Remove duplicate key `driveVersion` from info response.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
